### PR TITLE
chore: ignore modified rule ids file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+modifiedRuleIds.txt
 .history/
 node_modules/
 npm-debug.log


### PR DESCRIPTION
We don't want to accidentally add this to Git, so let's ignore it. Later we should allow output to custom file path, or `stdout`, or changing the output so it's optional (either opt-in, or opt-out).