### PR TITLE
chore: add prettier as devDep & run again

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,14 +19,18 @@ const addDisableCommentsToFileContents = (lineMeta, data) => {
   Object.entries(lineMeta).forEach(ruleMeta => {
     const [lineNumber, ruleIdsPerLine] = ruleMeta;
     const prevLine = fileContentsArr[lineNumber - 2];
-    const prevMatch = prevLine && prevLine.match(/\s*\/\/\s*eslint-disable-next-line\s+(.*)\s*/);
+    const prevMatch =
+      prevLine &&
+      prevLine.match(/\s*\/\/\s*eslint-disable-next-line\s+(.*)\s*/);
     const lineIndex = lineNumber - 1 + linePadding;
 
     if (prevMatch) {
       fileContentsArr.splice(
         lineIndex - 1,
         1,
-        `// eslint-disable-next-line ${prevMatch[1]}, ${ruleIdsPerLine.join(", ")}`
+        `// eslint-disable-next-line ${prevMatch[1]}, ${ruleIdsPerLine.join(
+          ", "
+        )}`
       );
     } else {
       fileContentsArr.splice(
@@ -103,7 +107,10 @@ const disableESLintIssues = results => {
           return;
         }
 
-        const { text, ruleIds } = addDisableCommentsToFileContents(lineMeta, data);
+        const { text, ruleIds } = addDisableCommentsToFileContents(
+          lineMeta,
+          data
+        );
 
         writeFile(filePath, text, log);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "jest",
-    "format": "npx prettier --write bin/index.js"
+    "format": "prettier --write bin/index.js"
   },
   "engines": {
     "node": ">=6.4.0"
@@ -24,6 +24,7 @@
     "eslint": "^5.12.0"
   },
   "devDependencies": {
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "prettier": "^1.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,6 +2541,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+
 pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"


### PR DESCRIPTION
Adding prettier as a devDep since some editor integrations won't auto-format on save unless this is the case. Also running it again since it wasn't run on some prior work.