### PR TITLE
docs: add quotes to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Options:
 ### Example:
 
 ```console
-$ npx disable-eslint-issues-cli src/**/*.js test/**/*.js
+$ npx disable-eslint-issues-cli 'src/**/*.js' 'test/**/*.js'
 ```


### PR DESCRIPTION
Seems the command works better when we pass the file globs as strings and let JS expand instead of letting the shell expand them.